### PR TITLE
Add multi-room slot interaction options

### DIFF
--- a/src/components/view/calendar/booking-slot/BookingSlot.svelte
+++ b/src/components/view/calendar/booking-slot/BookingSlot.svelte
@@ -10,15 +10,15 @@
 	import IconMobility from '$icons/IconMobility.svelte';
 	import { on } from 'svelte/events';
 
-	type Props = {
-		booking: FullBooking;
-		startHour: number;
-		hourHeight: number;
-		toolTipText?: string;
-		columnIndex?: number;
-		columnCount?: number;
-		onbookingselected: () => void;
-	};
+        type Props = {
+                booking: FullBooking;
+                startHour: number;
+                hourHeight: number;
+                toolTipText?: string;
+                columnIndex?: number;
+                columnCount?: number;
+                onbookingselected: (event: MouseEvent) => void;
+        };
 
 	let {
 		booking,

--- a/src/lib/stores/locationsStore.ts
+++ b/src/lib/stores/locationsStore.ts
@@ -1,19 +1,33 @@
 import { writable } from 'svelte/store';
 
+export type LocationRoom = {
+        id: number;
+        name: string;
+        half_hour_start?: boolean | null;
+        active?: boolean;
+};
+
 export type Location = {
-	id: number;
-	name: string;
+        id: number;
+        name: string;
+        color?: string;
+        rooms: LocationRoom[];
 };
 
 export const locations = writable<Location[]>([]);
 
 export async function fetchLocations() {
-	try {
-		const response = await fetch('/api/locations');
-		if (!response.ok) throw new Error('Failed to fetch locations');
-		const data: Location[] = await response.json();
-		locations.set(data);
-	} catch (error) {
-		console.error('Error fetching locations:', error);
-	}
+        try {
+                const response = await fetch('/api/locations');
+                if (!response.ok) throw new Error('Failed to fetch locations');
+                const data: Location[] = await response.json();
+                locations.set(
+                        data.map((location) => ({
+                                ...location,
+                                rooms: Array.isArray(location.rooms) ? location.rooms : []
+                        }))
+                );
+        } catch (error) {
+                console.error('Error fetching locations:', error);
+        }
 }


### PR DESCRIPTION
## Summary
- extend the locations store to retain room metadata for each location
- adjust calendar slot handling to decide between direct booking, slide-up actions, or a dialog when multiple rooms share a slot
- render a floating action panel and a keyboard-friendly HTML dialog so users can open or create bookings from overlapping slots

## Testing
- npm run lint *(fails: missing prettier-plugin-svelte in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900d811ada48327b77a719405739ddf